### PR TITLE
Referência circular

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,7 @@ jobs:
     - name: Check code smell
       run: |
         pylint **/*.py
+
+    - name: Check circular reference
+      run: |
+        pycycle --here

--- a/modulo_a.py
+++ b/modulo_a.py
@@ -1,0 +1,13 @@
+# modulo_a.py
+
+from modulo_b import func_b
+
+def func_a():
+    print("Função A")
+
+def call_b():
+    func_b()
+
+if __name__ == "__main__":
+    func_a()
+    call_b()

--- a/modulo_b.py
+++ b/modulo_b.py
@@ -1,0 +1,10 @@
+# modulo_b.py
+
+from modulo_a import func_a
+
+def func_b():
+    print("Função B")
+    func_a()
+
+if __name__ == "__main__":
+    func_b()

--- a/modulo_b.py
+++ b/modulo_b.py
@@ -1,7 +1,5 @@
 # modulo_b.py
 
-from modulo_a import func_a
-
 def func_b():
     print("Função B")
     func_a()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pylint==3.2.6
+pycycle


### PR DESCRIPTION
Adicionando o uso do detector de referência circular no pipeline do projeto. Resolvendo falhas reportadas de referência circular.

Rodando o comando de checagem:

![image](https://github.com/user-attachments/assets/c746427a-3ce2-4a7b-b2cd-4f6563807a21)

Executando novamente após a correção:

![image](https://github.com/user-attachments/assets/fef9dcb3-8de0-4d19-91da-a4f6275cac61)


